### PR TITLE
Inversion-free x-only Montgomery ladder (alternative point arithmetic)

### DIFF
--- a/XONLY_CONTRIBUTION.md
+++ b/XONLY_CONTRIBUTION.md
@@ -1,0 +1,86 @@
+# Inversion-free x-only Montgomery ladder (alternative point arithmetic)
+
+## Summary
+
+This contribution adds an **inversion-free x-only (projective `X:Z`) Montgomery
+ladder** as an alternative to the affine double-and-add engine in
+`src/quantum/ec_arithmetic.py`.
+
+The existing `q_ec_add_inpl` computes an affine slope, so it runs
+`kaliski_mod_inv` **twice per point addition** (compute λ + uncompute λ). Modular
+inversion is the single most expensive reversible primitive (Kaliski = `2n` loop
+iterations), so an `n`-bit scalar costs on the order of **~4n Kaliski inversions**
+on the critical path.
+
+The Montgomery ladder in projective `(X:Z)` coordinates removes every
+intermediate inversion: each step is built only from field
+multiply/square/add (`xDBL`, `xADD`), and a **single** inversion at the very end
+deaffinifies `x = X/Z`.
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `src/classical/xonly_reference.py` | Classical x-only ladder + field-op counter (ground-truth + resource model) |
+| `src/quantum/ec_arithmetic_xonly.py` | Qrisp `q_xDBL`, `q_xADD`, classical-`k` ladder, and quantum-`k` (controlled-swap) ladder |
+| `tests/test_xonly_reference.py` | Validates the x-only ladder against this repo's affine group law on **all** `curves_and_keys.json` curves; checks the inversion saving |
+| `tests/test_xonly_quantum.py` | Validates the Qrisp primitives + ladders under `boolean_simulation` on `p=13` |
+
+## Results
+
+**Classical (all 17 QDay curves, `a=0, b=7`)** — the x-only ladder reproduces
+every public key's x-coordinate and the loop uses exactly **one** inversion
+regardless of bit size, versus the `bit_length+hamming_weight-2` inversions of
+affine double-and-add:
+
+```
+inversions in the scalar-mult loop:   x-only = 1   |   affine ≈ 2n  (→ ~4n Kaliski in q_ec_add_inpl)
+17/17 curves: ladder_x(k, x(G)) == x(public_key)
+```
+
+**Quantum (`p=13`, `y²=x³+7`, `G=(11,5)`, `boolean_simulation`)**
+
+- `q_xDBL(G)` → `x(2G) = 7` ✓
+- `q_xADD(2G, G; diff=G)` → `x(3G) = 8` ✓
+- classical-`k` ladder: `x([2]G)=7`, `x([3]G)=8`, `x([5]G)=7` ✓
+- **quantum-`k` ladder (real Shor form)**: the scalar bits drive
+  controlled-swaps of `(R0,R1)`; `k=2` (cswap inactive) → `7`, `k=3`
+  (cswap active) → `8` ✓
+
+## Qrisp version note (important)
+
+Validated on **qrisp 0.9.5** (PyPI). `QuantumModulus`'s montgomery-shift
+behaviour differs between releases; three rules (documented inline in
+`ec_arithmetic_xonly.py`) make multiply/add/sub compose under
+`boolean_simulation`:
+
+1. Plain `A*B` decodes correctly and chains; a classical `*int` **resets** the
+   montgomery shift to 0 (the normalizer).
+2. `+`/`-` need equal shift: combine same-depth operands directly; when depths
+   differ, normalize **exactly one** side (`*1`). `_std(A) - _std(B)` is wrong.
+3. Never square a register by itself (`C*C`): use two independent products,
+   e.g. `(X1*X2)*(X1*X2)`.
+
+On the repo's pinned `0.8.2` branch, `QuantumModulus` has a montgomery
+`boolean_simulation` uncomputation bug (the repo's own `boolean_sim` test shows
+it), so these primitives should run against **qrisp ≥ 0.9.5**.
+
+## Limitations / future work
+
+- `boolean_simulation` takes classical inputs, so the quantum tests validate
+  **basis states** of `k` (the controlled-swap circuit is identical in
+  superposition — the genuine Shor use). True superposition needs statevector
+  simulation, which is qubit-limited.
+- qrisp 0.9.5's XLA compile is slow for deep circuits; the quantum-`k` ladder is
+  validated at `n=2` (one cswap iteration). Larger `n`/`p` need a faster
+  compiler or more memory.
+- The double-scalar `[k]G + [l]Q` Shor oracle is two ladders + one affine add;
+  composing it end-to-end in Qrisp is the natural next step.
+
+## How to run
+
+```bash
+pip install "qrisp>=0.9.5" pytest
+pytest tests/test_xonly_reference.py -q      # fast, no qrisp needed
+pytest tests/test_xonly_quantum.py -q        # slow (boolean_simulation JIT)
+```

--- a/src/classical/xonly_reference.py
+++ b/src/classical/xonly_reference.py
@@ -1,0 +1,128 @@
+"""Classical x-only (projective Kummer-line) reference for short Weierstrass
+curves y^2 = x^3 + a*x + b  (the QDay / secp256k1 family uses a=0, b=7).
+
+Motivation
+----------
+The quantum engine in `src/quantum/ec_arithmetic.py` performs scalar
+multiplication by affine double-and-add: every controlled point addition
+(`q_ec_add_inpl`) computes a slope and therefore runs `kaliski_mod_inv` TWICE
+(compute lambda + uncompute lambda).  Modular inversion is by far the most
+expensive reversible primitive (Kaliski = 2n loop iterations), so an n-bit scalar
+costs on the order of ~4n inversions on the critical path.
+
+The Montgomery ladder in projective (X:Z) coordinates removes every intermediate
+inversion: each step is built only from field multiplications/squarings/additions
+(xDBL / xADD), and a single inversion at the very end deaffinifies x = X/Z.  This
+module is the inversion-free reference; `tests/test_xonly_reference.py` validates
+it against this repo's own affine group law on every curve in
+`curves_and_keys.json` and quantifies the inversion saving.
+
+The quantum counterpart lives in `src/quantum/ec_arithmetic_xonly.py`.
+"""
+
+
+class FieldCounter:
+    """Prime field with operation counting (mul/sqr/add/inv) so we can quantify
+    the resource profile of each scalar-multiplication strategy."""
+
+    def __init__(self, p):
+        self.p = p
+        self.mul = self.sqr = self.add = self.inv = 0
+
+    def m(self, a, b):
+        self.mul += 1
+        return (a * b) % self.p
+
+    def s(self, a):
+        self.sqr += 1
+        return (a * a) % self.p
+
+    def add_(self, a, b):
+        self.add += 1
+        return (a + b) % self.p
+
+    def sub(self, a, b):
+        self.add += 1
+        return (a - b) % self.p
+
+    def cmul(self, k, a):
+        self.add += 1            # multiply by a small classical constant (cheap)
+        return (k * a) % self.p
+
+    def inverse(self, a):
+        self.inv += 1
+        return pow(a, -1, self.p)
+
+
+# ----------------------------------------------------------------------------
+# Projective x-only formulas (Izu-Takagi / Brier-Joye), short Weierstrass.
+# Difference point fixed = base point (xD : 1).
+# ----------------------------------------------------------------------------
+def xDBL(X1, Z1, a, b, F):
+    """(X1:Z1) -> x([2]P).  No inversion."""
+    X1sq = F.s(X1)
+    Z1sq = F.s(Z1)
+    aZ1sq = F.m(a, Z1sq) if a else 0
+    t = F.sub(X1sq, aZ1sq)
+    X2 = F.s(t)                                   # (X1^2 - a Z1^2)^2
+    Z1cu = F.m(Z1sq, Z1)
+    bX1Z1cu = F.m(b, F.m(X1, Z1cu))
+    X2 = F.sub(X2, F.cmul(8, bX1Z1cu))            # - 8 b X1 Z1^3
+    X1cu = F.m(X1sq, X1)
+    inner = X1cu
+    if a:
+        inner = F.add_(inner, F.m(a, F.m(X1, Z1sq)))
+    inner = F.add_(inner, F.m(b, Z1cu))           # X1^3 + a X1 Z1^2 + b Z1^3
+    Z2 = F.cmul(4, F.m(Z1, inner))
+    return X2, Z2
+
+
+def xADD(X1, Z1, X2, Z2, xD, a, b, F):
+    """Differential add (X1:Z1)+(X2:Z2) with known x(P-Q)=xD (Zd=1).  No inversion."""
+    X1X2 = F.m(X1, X2)
+    Z1Z2 = F.m(Z1, Z2)
+    X1Z2 = F.m(X1, Z2)
+    X2Z1 = F.m(X2, Z1)
+    t1 = F.sub(X1X2, F.m(a, Z1Z2)) if a else X1X2
+    t1 = F.s(t1)
+    t2 = F.m(F.cmul(4, F.m(b, Z1Z2)), F.add_(X1Z2, X2Z1))
+    Xp = F.sub(t1, t2)
+    Zp = F.m(xD, F.s(F.sub(X1Z2, X2Z1)))
+    return Xp, Zp
+
+
+def ladder_x(k, xP, a, b, F):
+    """Return affine x([k]P) via the x-only ladder.  ONE inversion at the end."""
+    n = k.bit_length()
+    if n == 0:
+        return None
+    X0, Z0 = xP, 1
+    X1, Z1 = xDBL(xP, 1, a, b, F)
+    for i in range(n - 2, -1, -1):
+        if (k >> i) & 1:
+            X0, Z0 = xADD(X0, Z0, X1, Z1, xP, a, b, F)
+            X1, Z1 = xDBL(X1, Z1, a, b, F)
+        else:
+            X1, Z1 = xADD(X0, Z0, X1, Z1, xP, a, b, F)
+            X0, Z0 = xDBL(X0, Z0, a, b, F)
+    if Z0 == 0:
+        return None
+    return F.m(X0, F.inverse(Z0))
+
+
+def affine_doubleadd_inversions(k):
+    """Number of modular inversions an affine double-and-add scalar mult uses
+    (one per non-trivial add/double) -- the cost driver of the current quantum
+    q_ec_add_inpl, which turns each into TWO Kaliski inversions."""
+    invs = 0
+    has_R = False
+    Q_is_zero = False
+    bits = k.bit_length()
+    for i in range(bits):
+        if (k >> i) & 1:
+            if has_R:
+                invs += 1          # affine addition
+            has_R = True
+        if i < bits - 1:
+            invs += 1              # doubling
+    return invs

--- a/src/quantum/ec_arithmetic_xonly.py
+++ b/src/quantum/ec_arithmetic_xonly.py
@@ -1,0 +1,113 @@
+"""Inversion-free x-only (projective X:Z) elliptic-curve arithmetic in Qrisp.
+
+This is an alternative to the affine engine in `ec_arithmetic.py`.  The affine
+`q_ec_add_inpl` runs `kaliski_mod_inv` twice per point addition; a Montgomery
+ladder built from the primitives below uses NO modular inversion in the loop
+(only field mul/sqr/add), deferring a single inversion to the final X/Z
+deaffinify after measurement.  See `src/classical/xonly_reference.py` for the
+classical ground truth and the inversion-count comparison.
+
+Curve: short Weierstrass y^2 = x^3 + a x + b, a = 0 path (secp256k1 / QDay family).
+
+Qrisp version note
+------------------
+Validated on qrisp 0.9.5 (PyPI).  The montgomery-shift behaviour of
+QuantumModulus differs between releases; three rules (discovered empirically and
+documented inline) make multiply/add/sub compose correctly under
+`boolean_simulation` on 0.9.5:
+
+  1. Plain `A*B` decodes correctly and chains; its montgomery shift accumulates
+     as m(A*B) = m(A)+m(B)-m_red.  A classical const-mult `C*int` RESETS shift
+     to 0 (it is the normalizer).
+  2. `+`/`-` require equal shift: operands at the SAME depth are combined
+     directly; when depths differ, normalize exactly ONE side via `_std` (a `*1`).
+     Do NOT normalize both sides of a subtraction (`_std(A)-_std(B)` is wrong).
+  3. Never multiply a register by itself (`C*C`): squarings use two INDEPENDENT
+     products, e.g. `(X1*X2)*(X1*X2)`.
+
+Under 0.8.2 (this repo's pinned branch) QuantumModulus has a montgomery
+boolean_simulation uncomputation bug (the repo's own boolean_sim test exhibits
+it), so these primitives should be run against qrisp >= 0.9.5.
+"""
+from qrisp import QuantumModulus, control, swap
+
+
+def _std(C):
+    """Normalize montgomery shift to 0 via a classical *1 (preserves value)."""
+    return C * 1
+
+
+def q_xDBL(X1, Z1, a, b, p):
+    """x-only projective doubling (a=0). Returns (X2, Z2). Inversion-free."""
+    c8b = (8 * b) % p
+    bm = b % p
+    X1sq = X1 * X1
+    Z1sq = Z1 * Z1
+    Z1cu = Z1sq * Z1
+    X1cu = X1sq * X1
+    X1q = X1sq * X1sq          # X1^4   (shift -3 m_red, same as X1Z1cu)
+    X1Z1cu = X1 * Z1cu         # X1 Z1^3
+    X2 = _std(X1q) - X1Z1cu * c8b      # one-sided _std vs const-product
+    inner = _std(X1cu) + Z1cu * bm     # one-sided _std vs const-product
+    Z2 = (Z1 * inner) * (4 % p)
+    return X2, Z2
+
+
+def q_xADD(X1, Z1, X2, Z2, xD, a, b, p):
+    """x-only differential addition (a=0, difference Zd=1, Xd=xD). Returns (Xp, Zp)."""
+    c4b = (4 * b) % p
+    sq = (X1 * X2) * (X1 * X2)          # (X1 X2)^2 via two independent products
+    Z1Z2 = Z1 * Z2
+    X1Z2 = X1 * Z2
+    X2Z1 = X2 * Z1
+    sumXZ = X1Z2 + X2Z1                 # same shift -> direct
+    term = (Z1Z2 * sumXZ) * c4b
+    Xp = _std(sq) - term
+    diffA = (X1 * Z2) - (X2 * Z1)       # two independent differences (no self-mul)
+    diffB = (X1 * Z2) - (X2 * Z1)
+    Zp = (diffA * diffB) * (xD % p)
+    return Xp, Zp
+
+
+def q_ladder_x(k, xG, twoGx, a, b, p):
+    """Classical scalar k: full Montgomery ladder, returns projective (X0:Z0)=x([k]G).
+    Inversion-free loop. `twoGx` = affine x(2G)."""
+    n = k.bit_length()
+    X0 = QuantumModulus(p); X0[:] = xG
+    Z0 = QuantumModulus(p); Z0[:] = 1
+    X1 = QuantumModulus(p); X1[:] = twoGx
+    Z1 = QuantumModulus(p); Z1[:] = 1
+    for i in range(n - 2, -1, -1):
+        if (k >> i) & 1:
+            X0, Z0 = q_xADD(X0, Z0, X1, Z1, xG, a, b, p)
+            X1, Z1 = q_xDBL(X1, Z1, a, b, p)
+        else:
+            X1, Z1 = q_xADD(X0, Z0, X1, Z1, xG, a, b, p)
+            X0, Z0 = q_xDBL(X0, Z0, a, b, p)
+    return X0, Z0
+
+
+def _cswap(ctrl, A, B):
+    with control(ctrl):
+        swap(A, B)
+
+
+def q_ladder_quantum(kbits_low, xG, twoGx, a, b, p):
+    """Quantum scalar (real Shor form): the scalar bits drive CONTROLLED-SWAPs of
+    the ladder points instead of classical branching.  With the bits in
+    superposition the same circuit computes x([k]G) for all k at once.
+
+    Assumes the MSB is 1 (true for Bitcoin-puzzle keys k in [2^(n-1), 2^n)), so
+    R0=G, R1=2G are the post-MSB state; `kbits_low` are the QuantumBools for the
+    remaining bits, ordered MSB-1 .. 0.  Returns projective (X0:Z0)=x([k]G)."""
+    X0 = QuantumModulus(p); X0[:] = xG
+    Z0 = QuantumModulus(p); Z0[:] = 1
+    X1 = QuantumModulus(p); X1[:] = twoGx
+    Z1 = QuantumModulus(p); Z1[:] = 1
+    for kbit in kbits_low:
+        _cswap(kbit, X0, X1); _cswap(kbit, Z0, Z1)
+        nX1, nZ1 = q_xADD(X0, Z0, X1, Z1, xG, a, b, p)   # R1 <- R0 + R1
+        nX0, nZ0 = q_xDBL(X0, Z0, a, b, p)               # R0 <- 2 R0
+        _cswap(kbit, nX0, nX1); _cswap(kbit, nZ0, nZ1)
+        X0, Z0, X1, Z1 = nX0, nZ0, nX1, nZ1
+    return X0, Z0

--- a/tests/test_xonly_quantum.py
+++ b/tests/test_xonly_quantum.py
@@ -1,0 +1,88 @@
+"""Quantum validation of the inversion-free x-only primitives and ladder under
+boolean_simulation, on the smallest QDay curve (p=13, y^2=x^3+7, G=(11,5)).
+
+Requires qrisp >= 0.9.5 (see the version note in
+src/quantum/ec_arithmetic_xonly.py).  These run boolean_simulation and are slow
+to JIT-compile, so they are kept to small basis-state cases.
+"""
+import pytest
+
+qrisp = pytest.importorskip("qrisp")
+from qrisp import QuantumModulus, QuantumBool, boolean_simulation, measure
+
+import src.classical.ec_arithmetic as cl
+import src.quantum.ec_arithmetic_xonly as xq
+
+P, A, B = 13, 0, 7
+G = (11, 5)
+CURVE = cl.EllCurve(a=A, b=B, p=P)
+
+
+def _scalar(k):
+    R = cl.ell_mult_add(cl.EllPoint(*G), cl.EllZero, k, CURVE)
+    return (R.x, R.y)
+
+
+def _deaffinify(Xv, Zv):
+    return (Xv * pow(Zv, -1, P)) % P if Zv else None
+
+
+TWO_GX = _scalar(2)[0]
+
+
+def test_q_xDBL():
+    @boolean_simulation
+    def run():
+        X1 = QuantumModulus(P); X1[:] = G[0]
+        Z1 = QuantumModulus(P); Z1[:] = 1
+        X2, Z2 = xq.q_xDBL(X1, Z1, A, B, P)
+        return measure(X2), measure(Z2)
+
+    Xv, Zv = (int(v) for v in run())
+    assert _deaffinify(Xv, Zv) == _scalar(2)[0]
+
+
+def test_q_xADD():
+    @boolean_simulation
+    def run():
+        X1 = QuantumModulus(P); X1[:] = _scalar(2)[0]   # 2G
+        Z1 = QuantumModulus(P); Z1[:] = 1
+        X2 = QuantumModulus(P); X2[:] = G[0]            # G ; difference = G
+        Z2 = QuantumModulus(P); Z2[:] = 1
+        Xp, Zp = xq.q_xADD(X1, Z1, X2, Z2, G[0], A, B, P)
+        return measure(Xp), measure(Zp)
+
+    Xv, Zv = (int(v) for v in run())
+    assert _deaffinify(Xv, Zv) == _scalar(3)[0]
+
+
+@pytest.mark.parametrize("k", [2, 3, 5])
+def test_q_ladder_classical_scalar(k):
+    @boolean_simulation
+    def run():
+        X0, Z0 = xq.q_ladder_x(k, G[0], TWO_GX, A, B, P)
+        return measure(X0), measure(Z0)
+
+    Xv, Zv = (int(v) for v in run())
+    assert _deaffinify(Xv, Zv) == _scalar(k)[0]
+
+
+@pytest.mark.parametrize("k", [2, 3])  # n=2, MSB=1 -> one cswap iteration
+def test_q_ladder_quantum_scalar_cswap(k):
+    """Real Shor form: scalar bits drive controlled-swaps of the ladder points."""
+    n = 2
+    low_bits = [(k >> i) & 1 for i in range(n - 2, -1, -1)]
+
+    @boolean_simulation
+    def run():
+        kbits = []
+        for bval in low_bits:
+            qb = QuantumBool()
+            if bval:
+                qb[:] = True
+            kbits.append(qb)
+        X0, Z0 = xq.q_ladder_quantum(kbits, G[0], TWO_GX, A, B, P)
+        return measure(X0), measure(Z0)
+
+    Xv, Zv = (int(v) for v in run())
+    assert _deaffinify(Xv, Zv) == _scalar(k)[0]

--- a/tests/test_xonly_reference.py
+++ b/tests/test_xonly_reference.py
@@ -1,0 +1,54 @@
+"""Classical validation of the inversion-free x-only ladder against this repo's
+own affine group law, on every curve in curves_and_keys.json, plus the
+inversion-count comparison that motivates the contribution."""
+import json
+import os
+
+import pytest
+
+import src.classical.ec_arithmetic as cl
+import src.classical.xonly_reference as xo
+
+_HERE = os.path.dirname(__file__)
+with open(os.path.join(_HERE, "..", "curves_and_keys.json")) as _fh:
+    CURVES = json.load(_fh)
+
+A, B = 0, 7  # QDay / secp256k1 family
+
+
+@pytest.mark.parametrize("c", CURVES, ids=lambda c: f"{c['bit_length']}bit")
+def test_xonly_ladder_matches_affine_reference(c):
+    p = c["prime"]
+    G = tuple(c["generator_point"])
+    k = c["private_key"]
+    pub = tuple(c["public_key"])
+
+    # sanity: the curve really is y^2 = x^3 + 7
+    assert (G[1] * G[1] - G[0] ** 3 - B) % p == 0
+
+    # ground truth from this repo's own classical group law
+    curve = cl.EllCurve(a=A, b=B, p=p)
+    ref = cl.ell_mult_add(cl.EllPoint(*G), cl.EllZero, k, curve)
+    assert (ref.x, ref.y) == pub
+
+    # x-only ladder must reproduce the public key's x-coordinate
+    F = xo.FieldCounter(p)
+    x = xo.ladder_x(k, G[0], A, B, F)
+    assert x == pub[0]
+
+    # ...using exactly ONE modular inversion (the final X/Z deaffinify),
+    # whereas affine double-and-add needs one inversion per doubling/addition
+    # (>= bit_length-1), each of which becomes TWO Kaliski inversions in the
+    # current quantum q_ec_add_inpl.
+    assert F.inv == 1
+    affine_inv = xo.affine_doubleadd_inversions(k)
+    assert affine_inv >= k.bit_length() - 1
+    assert affine_inv > F.inv
+
+
+def test_inversion_saving_is_independent_of_bitsize():
+    """The x-only loop is inversion-free at every size; affine grows ~2n."""
+    for c in CURVES:
+        F = xo.FieldCounter(c["prime"])
+        xo.ladder_x(c["private_key"], c["generator_point"][0], A, B, F)
+        assert F.inv == 1


### PR DESCRIPTION
# Inversion-free x-only Montgomery ladder (alternative point arithmetic)

## Summary

This contribution adds an **inversion-free x-only (projective `X:Z`) Montgomery
ladder** as an alternative to the affine double-and-add engine in
`src/quantum/ec_arithmetic.py`.

The existing `q_ec_add_inpl` computes an affine slope, so it runs
`kaliski_mod_inv` **twice per point addition** (compute λ + uncompute λ). Modular
inversion is the single most expensive reversible primitive (Kaliski = `2n` loop
iterations), so an `n`-bit scalar costs on the order of **~4n Kaliski inversions**
on the critical path.

The Montgomery ladder in projective `(X:Z)` coordinates removes every
intermediate inversion: each step is built only from field
multiply/square/add (`xDBL`, `xADD`), and a **single** inversion at the very end
deaffinifies `x = X/Z`.

## Files

| File | Purpose |
|------|---------|
| `src/classical/xonly_reference.py` | Classical x-only ladder + field-op counter (ground-truth + resource model) |
| `src/quantum/ec_arithmetic_xonly.py` | Qrisp `q_xDBL`, `q_xADD`, classical-`k` ladder, and quantum-`k` (controlled-swap) ladder |
| `tests/test_xonly_reference.py` | Validates the x-only ladder against this repo's affine group law on **all** `curves_and_keys.json` curves; checks the inversion saving |
| `tests/test_xonly_quantum.py` | Validates the Qrisp primitives + ladders under `boolean_simulation` on `p=13` |

## Results

**Classical (all 17 QDay curves, `a=0, b=7`)** — the x-only ladder reproduces
every public key's x-coordinate and the loop uses exactly **one** inversion
regardless of bit size, versus the `bit_length+hamming_weight-2` inversions of
affine double-and-add:

```
inversions in the scalar-mult loop:   x-only = 1   |   affine ≈ 2n  (→ ~4n Kaliski in q_ec_add_inpl)
17/17 curves: ladder_x(k, x(G)) == x(public_key)
```

**Quantum (`p=13`, `y²=x³+7`, `G=(11,5)`, `boolean_simulation`)**

- `q_xDBL(G)` → `x(2G) = 7` ✓
- `q_xADD(2G, G; diff=G)` → `x(3G) = 8` ✓
- classical-`k` ladder: `x([2]G)=7`, `x([3]G)=8`, `x([5]G)=7` ✓
- **quantum-`k` ladder (real Shor form)**: the scalar bits drive
  controlled-swaps of `(R0,R1)`; `k=2` (cswap inactive) → `7`, `k=3`
  (cswap active) → `8` ✓

## Qrisp version note (important)

Validated on **qrisp 0.9.5** (PyPI). `QuantumModulus`'s montgomery-shift
behaviour differs between releases; three rules (documented inline in
`ec_arithmetic_xonly.py`) make multiply/add/sub compose under
`boolean_simulation`:

1. Plain `A*B` decodes correctly and chains; a classical `*int` **resets** the
   montgomery shift to 0 (the normalizer).
2. `+`/`-` need equal shift: combine same-depth operands directly; when depths
   differ, normalize **exactly one** side (`*1`). `_std(A) - _std(B)` is wrong.
3. Never square a register by itself (`C*C`): use two independent products,
   e.g. `(X1*X2)*(X1*X2)`.

On the repo's pinned `0.8.2` branch, `QuantumModulus` has a montgomery
`boolean_simulation` uncomputation bug (the repo's own `boolean_sim` test shows
it), so these primitives should run against **qrisp ≥ 0.9.5**.

## Limitations / future work

- `boolean_simulation` takes classical inputs, so the quantum tests validate
  **basis states** of `k` (the controlled-swap circuit is identical in
  superposition — the genuine Shor use). True superposition needs statevector
  simulation, which is qubit-limited.
- qrisp 0.9.5's XLA compile is slow for deep circuits; the quantum-`k` ladder is
  validated at `n=2` (one cswap iteration). Larger `n`/`p` need a faster
  compiler or more memory.
- The double-scalar `[k]G + [l]Q` Shor oracle is two ladders + one affine add;
  composing it end-to-end in Qrisp is the natural next step.

## How to run

```bash
pip install "qrisp>=0.9.5" pytest
pytest tests/test_xonly_reference.py -q      # fast, no qrisp needed
pytest tests/test_xonly_quantum.py -q        # slow (boolean_simulation JIT)
```

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
